### PR TITLE
fix: Bitcoin service uses the wrong env var and network

### DIFF
--- a/docker/docker-compose-bitcoin.yml
+++ b/docker/docker-compose-bitcoin.yml
@@ -13,7 +13,7 @@ services:
       - "bitcoin_data:/bitcoind/.bitcoin"
     restart: always
     networks:
-      - default
+      - bitcoind
 
 volumes:
   bitcoin_data:


### PR DESCRIPTION
## Summary

This PR fixes the wrong env var and network for the Bitcoin service.

## Test Plan

```
make start-bitcoin
```

the docker service should run on the right RPC port.