### PR TITLE
fix: finality gadget circular deps

### DIFF
--- a/.env.babylon-integration.example
+++ b/.env.babylon-integration.example
@@ -60,4 +60,4 @@ STAKING_TIME=10000 # ~70 days
 STAKING_AMOUNT=10000 # 0.0001 BTC
 
 # Finality Explorer Configuration
-NEXT_PUBLIC_FINALITY_GADGET_API_URL=https://tohma.finality-gadget.snapcha.in
+NEXT_PUBLIC_FINALITY_GADGET_API_URL=http://11.22.33.44:8545

--- a/configs/babylon-integration/opfgd.toml
+++ b/configs/babylon-integration/opfgd.toml
@@ -10,3 +10,4 @@ BBNRPCAddress = "${BABYLON_RPC_URL}"
 GRPCListener = "0.0.0.0:50051"
 HTTPListener = "0.0.0.0:8080"
 PollInterval = "10s"
+BatchSize = 10

--- a/docker/docker-compose-babylon-integration.yml
+++ b/docker/docker-compose-babylon-integration.yml
@@ -98,8 +98,8 @@ services:
 
   finality-gadget:
     container_name: finality-gadget
-    # https://github.com/babylonlabs-io/finality-gadget/commit/c6b7e474800e32600af0d158052164c515f4a54b
-    image: babylonlabs/finality-gadget:c6b7e474800e32600af0d158052164c515f4a54b
+    # https://github.com/babylonlabs-io/finality-gadget/commit/10a0fc1668b57cdbb5f39b7230346aa208839dab
+    image: babylonlabs/finality-gadget:10a0fc1668b57cdbb5f39b7230346aa208839dab
     command: >
       opfgd start --cfg /home/finality-gadget/opfgd.toml
     ports:

--- a/docker/docker-compose-babylon-integration.yml
+++ b/docker/docker-compose-babylon-integration.yml
@@ -98,8 +98,8 @@ services:
 
   finality-gadget:
     container_name: finality-gadget
-    # https://github.com/babylonlabs-io/finality-gadget/commit/10a0fc1668b57cdbb5f39b7230346aa208839dab
-    image: babylonlabs/finality-gadget:10a0fc1668b57cdbb5f39b7230346aa208839dab
+    # https://github.com/babylonlabs-io/finality-gadget/commit/9f7ee4c7c9ba7b07645a9aa3f79dc88987b0815a
+    image: babylonlabs/finality-gadget:9f7ee4c7c9ba7b07645a9aa3f79dc88987b0815a
     command: >
       opfgd start --cfg /home/finality-gadget/opfgd.toml
     ports:

--- a/docker/docker-compose-babylon-integration.yml
+++ b/docker/docker-compose-babylon-integration.yml
@@ -55,9 +55,9 @@ services:
 
   btc-staker:
     container_name: btc-staker
-    # https://github.com/babylonlabs-io/btc-staker/commit/c6b7e474800e32600af0d158052164c515f4a54b
+    # https://github.com/babylonlabs-io/btc-staker/commit/484bcb8fd9b7b0b525234d704dd049b1ef18e29f
     # euphrates-0.5.0-rc.0
-    image: babylonlabs/btc-staker:c6b7e474800e32600af0d158052164c515f4a54b
+    image: babylonlabs/btc-staker:484bcb8fd9b7b0b525234d704dd049b1ef18e29f
     env_file:
       - "${PWD}/.env.babylon-integration"
     volumes:
@@ -98,8 +98,8 @@ services:
 
   finality-gadget:
     container_name: finality-gadget
-    # https://github.com/babylonlabs-io/finality-gadget/commit/0a26e66ed86a65e37788e5ba8fcf9154fc92f6bd
-    image: babylonlabs/finality-gadget:0a26e66ed86a65e37788e5ba8fcf9154fc92f6bd
+    # https://github.com/babylonlabs-io/finality-gadget/commit/c6b7e474800e32600af0d158052164c515f4a54b
+    image: babylonlabs/finality-gadget:c6b7e474800e32600af0d158052164c515f4a54b
     command: >
       opfgd start --cfg /home/finality-gadget/opfgd.toml
     ports:

--- a/docker/docker-compose-babylon-integration.yml
+++ b/docker/docker-compose-babylon-integration.yml
@@ -55,9 +55,9 @@ services:
 
   btc-staker:
     container_name: btc-staker
-    # https://github.com/babylonlabs-io/btc-staker/commit/484bcb8fd9b7b0b525234d704dd049b1ef18e29f
+    # https://github.com/babylonlabs-io/btc-staker/commit/c6b7e474800e32600af0d158052164c515f4a54b
     # euphrates-0.5.0-rc.0
-    image: babylonlabs/btc-staker:484bcb8fd9b7b0b525234d704dd049b1ef18e29f
+    image: babylonlabs/btc-staker:c6b7e474800e32600af0d158052164c515f4a54b
     env_file:
       - "${PWD}/.env.babylon-integration"
     volumes:

--- a/docker/docker-compose-babylon-integration.yml
+++ b/docker/docker-compose-babylon-integration.yml
@@ -98,8 +98,8 @@ services:
 
   finality-gadget:
     container_name: finality-gadget
-    # https://github.com/babylonlabs-io/finality-gadget/commit/37a8b1c9b2698c9967bbc060583668d6c7a1e6f9
-    image: babylonlabs/finality-gadget:37a8b1c9b2698c9967bbc060583668d6c7a1e6f9
+    # https://github.com/babylonlabs-io/finality-gadget/commit/0a26e66ed86a65e37788e5ba8fcf9154fc92f6bd
+    image: babylonlabs/finality-gadget:0a26e66ed86a65e37788e5ba8fcf9154fc92f6bd
     command: >
       opfgd start --cfg /home/finality-gadget/opfgd.toml
     ports:


### PR DESCRIPTION
## Summary

This PR:
- updates the `finality-gadget` to new image that fixes circular deps issue (see https://github.com/babylonlabs-io/finality-gadget/pull/35 and https://github.com/babylonlabs-io/finality-gadget/pull/38)
- add `BatchSize` to `opfgd.toml`
- update example env vars

## Test plan
```
make start-finality-gadget
```