### PR TITLE
docs: update integration guide

### DIFF
--- a/.env.babylon-integration.example
+++ b/.env.babylon-integration.example
@@ -14,6 +14,8 @@ BITCOIN_NETWORK=signet
 BITCOIN_RPC_HOST=11.22.33.44:38332 # gRPC
 BITCOIN_RPC_USER=snapchain
 BITCOIN_RPC_PASS=rpcpass
+# TODO: there is no need to make these ports configurable. should just have one BITCOIN_NODE_IP var
+# and use it here and for BITCOIN_RPC_HOST 
 ZMQ_RAWBLOCK_URL=tcp://11.22.33.44:29001
 ZMQ_RAWTR_URL=tcp://11.22.33.44:29002
 

--- a/.env.babylon-integration.example
+++ b/.env.babylon-integration.example
@@ -33,7 +33,7 @@ BABYLON_PREFUNDED_KEY=snapchain
 BABYLON_PREFUNDED_KEY_MNEMONIC="your mnemonic here"
 
 # Consumer chain configuration
-CONSUMER_ID=op-chain-706114
+CONSUMER_ID=op-stack-tohma-706114-0001
 CONSUMER_CHAIN_NAME="Snapchain Tohma"
 
 # Deploy CW contract

--- a/.env.bitcoin.example
+++ b/.env.bitcoin.example
@@ -1,5 +1,5 @@
-NETWORK=regtest # regtest | signet
-RPC_PORT=18443 # 18443 (regtest) | 38332 (signet)
+NETWORK=signet # regtest | signet
+RPC_PORT=38332 # 18443 (regtest) | 38332 (signet)
 RPC_USER=snapchain
 RPC_PASS=rpcpass
 BTC_WALLET_NAME=btcwallet

--- a/.env.bitcoin.example
+++ b/.env.bitcoin.example
@@ -2,12 +2,13 @@ NETWORK=signet # regtest | signet
 RPC_PORT=38332 # 18443 (regtest) | 38332 (signet)
 RPC_USER=snapchain
 RPC_PASS=rpcpass
+# TODO: there is no need to make these ports configurable.
+ZMQ_SEQUENCE_PORT=29000
+ZMQ_RAWBLOCK_PORT=29001
+ZMQ_RAWTR_PORT=29002
 BTC_WALLET_NAME=btcwallet
 BTC_WALLET_PASS=walletpass
 # btc private key in WIF format
 BTC_PRIVKEY=cRvCqiuhGEPeCpkcwttMbNSMDkkaEXmMxSmLWJjPPXzgB3CjdcaS
-ZMQ_SEQUENCE_PORT=29000
-ZMQ_RAWBLOCK_PORT=29001
-ZMQ_RAWTR_PORT=29002
 # only used if BITCOIN_NETWORK=regtest
 GENERATE_INTERVAL_SECS=600 # 10 minutes

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Replace the IP with your server's IP in the following variables:
 - `ZMQ_RAWTX_URL`: for the Bitcoin Signet node.
 - `CONSUMER_EOTS_MANAGER_ADDRESS`
 - `FINALITY_GADGET_RPC`
+- `NEXT_PUBLIC_FINALITY_GADGET_API_URL`: for the finality explorer.
 
 Configure the following variables:
 - `BABYLON_PREFUNDED_KEY_MNEMONIC`: the mnemonic for the address you used to claim BBN tokens in the previous step.
@@ -198,6 +199,18 @@ Once the BTC delegation is activated, set the `IS_ENABLED=true` in the `.env.bab
 ```bash
 make toggle-cw-killswitch
 ```
+
+### 12. Start the finality explorer
+
+```bash
+make start-finality-explorer
+```
+
+### 13. Verify the integration
+
+You can verify the integration by creating a transaction on the L2 chain and verify it's finalization status in the finality explorer. It should take just a few seconds to be BTC-finalized, thus enabling fast finality in various use cases.
+
+If you plan to build any applications using the fast finality feature, feel free to reach out to us at [info@snapchain.dev](mailto:info@snapchain.dev).
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
-# babylon-deployment
+# BTC Staking Integration for OP-Stack Chains
+
+This guide describes how to integreate the Babylon Bitcoin Staking protocol to an OP-Stack chain.
+
+The OP-Stack chain is recommended to be deployed using https://github.com/Snapchain/op-chain-deployment.
+
+It's recommended you skim through this guide before starting the following steps.
+
+## System Recommendations
+
+The guide was tested on:
+- a Debian 12 x64 machine on Digital Ocean
+- 8GB Memory
+- 160GB Disk
+
+It's recommended you execute the following steps on a similar machine.
 
 ## Dependencies
+
+The following dependencies are required on your machine.
 
 | Dependency      | Version | Version Check Command |
 | ----------- | ----------- | ----------- |
@@ -14,14 +31,16 @@
 
 ## Setup Bitcoin node
 
+A Bitcoin node is required to run the Babylon BTC Staker. You will need to import a private key with some BTC into the Bitcoin node. If you don't have one, you can generate a new account using OKX wallet and export the private key. To get some test BTC, you can use faucets such as https://signetfaucet.com/. To integrate with Babylon Euphrates 0.5.0 devnet, you need to use the signet network.
+
 1. Copy the `.env.bitcoin.example` file to `.env.bitcoin` and set the variables
 
     ```bash
     cp .env.bitcoin.example .env.bitcoin
     ```
 
-* The `NETWORK` variable only can be either `regtest` or `signet`.
-* The `BTC_PRIVKEY` variable must be a valid Bitcoin private key in WIF format.
+    * The `NETWORK` variable can be either `regtest` or `signet`.
+    * The `BTC_PRIVKEY` variable must be a valid Bitcoin private key in WIF format.
 
 2. Start the Bitcoin node
 
@@ -35,16 +54,18 @@
     make verify-bitcoin-sync-balance
     ```
 
-4. Stop the Bitcoin node
+    Note: this step may take ~10 minutes to complete.
 
-    ```bash
-    make stop-bitcoin
-    ```
-
-5. Check the Bitcoin node logs
+If you want to check the Bitcoin node logs, you can run the following command:
 
     ```bash
     docker compose -f docker/docker-compose-bitcoin.yml logs -f bitcoind
+    ```
+
+If you want to stop the Bitcoin node (and remove the synced data), you can run the following command:
+
+    ```bash
+    make stop-bitcoin
     ```
 
 ## Integrate Babylon finality system with OP Stack chain
@@ -53,11 +74,11 @@ This section describes how to integrate Babylon finality system to Babylon Euphr
 
 Before starting the following steps, please make sure:
 
-* your Bitcoin node is synced and has a wallet that has BTC balance on your specified network.
-* your OP Stack chain is running and have at least one finalized block. For more details about how to setup OP Stack chain, please refer to the [OP chain deployment](https://github.com/Snapchain/op-chain-deployment/blob/main/README.md).
+* your Bitcoin Signet node is synced and has a wallet that has signet BTC balance.
+* your OP Stack chain is running and have at least one finalized block. For more details about how to setup an OP Stack chain with BTC staking support, please refer to the [OP chain deployment](https://github.com/Snapchain/op-chain-deployment/blob/main/README.md) repo.
 
 
-Firstly, please get some test tokens from the Euphrates faucet
+### 1. Get some test BBN tokens from the Euphrates faucet
 
 ```bash
 curl https://faucet-euphrates.devnet.babylonlabs.io/claim \
@@ -65,7 +86,7 @@ curl https://faucet-euphrates.devnet.babylonlabs.io/claim \
 -d '{ "address": "<YOUR_BABYLON_ADDRESS>"}'
 ```
 
-### 1. Setup environment variables
+### 2. Setup environment variables
 
 Copy the `.env.babylon-integration.example` file to `.env.babylon-integration`
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ make start-finality-explorer
 
 ### 13. Verify the integration
 
-You can verify the integration by creating a transaction on the L2 chain and verify it's finalization status in the finality explorer. It should take just a few seconds to be BTC-finalized, thus enabling fast finality in various use cases.
+You can verify the integration by creating a transaction on the L2 chain and verify its finalization status in the finality explorer. It should take just a few seconds to be BTC-finalized, thus enabling fast finality in various use cases.
 
 If you plan to build any applications using the fast finality feature, feel free to reach out to us at [info@snapchain.dev](mailto:info@snapchain.dev).
 

--- a/README.md
+++ b/README.md
@@ -1,60 +1,60 @@
 # BTC Staking Integration for OP-Stack Chains
 
-This guide describes how to integreate the Babylon Bitcoin Staking protocol to an OP-Stack chain.
+This guide describes how to integrate the Babylon Bitcoin Staking protocol to an OP-Stack chain.
 
-The OP-Stack chain is recommended to be deployed using https://github.com/Snapchain/op-chain-deployment.
+It assumes you already have an OP-Stack chain deployed. If not, we recommend deploying an OP-Stack devnet using our [OP chain deployment](https://github.com/Snapchain/op-chain-deployment) repo.
 
-It's recommended you skim through this guide before starting the following steps.
+It's recommended you skim through this guide before starting with the following steps.
 
 ## System Recommendations
 
 The guide was tested on:
+
 - a Debian 12 x64 machine on Digital Ocean
 - 8GB Memory
 - 160GB Disk
 
-It's recommended you execute the following steps on a similar machine.
+It's recommended you execute the following steps on a similar or better machine.
 
 ## Dependencies
 
 The following dependencies are required on your machine.
 
-| Dependency      | Version | Version Check Command |
-| ----------- | ----------- | ----------- |
-| [git](https://git-scm.com/)      | ^2       | `git --version`       |
-| [docker](https://www.docker.com/)      | ^20       | `docker --version`       |
-| [docker compose](https://docs.docker.com/compose/)      | ^2.20       | `docker compose version`       |
-| [make](https://linux.die.net/man/1/make)      | ^3       | `make --version`       |
-| [curl](https://curl.se/)      | ^8       | `curl --version`       |
-| [jq](https://github.com/jqlang/jq)      | ^1.6       | `jq --version`       |
-
+| Dependency                                         | Version | Version Check Command    |
+| -------------------------------------------------- | ------- | ------------------------ |
+| [git](https://git-scm.com/)                        | ^2      | `git --version`          |
+| [docker](https://www.docker.com/)                  | ^20     | `docker --version`       |
+| [docker compose](https://docs.docker.com/compose/) | ^2.20   | `docker compose version` |
+| [make](https://linux.die.net/man/1/make)           | ^3      | `make --version`         |
+| [curl](https://curl.se/)                           | ^8      | `curl --version`         |
+| [jq](https://github.com/jqlang/jq)                 | ^1.6    | `jq --version`           |
 
 ## Setup Bitcoin node
 
-A Bitcoin node is required to run the Babylon BTC Staker. You will need to import a private key with some BTC into the Bitcoin node. If you don't have one, you can generate a new account using OKX wallet and export the private key. To get some test BTC, you can use faucets such as https://signetfaucet.com/. To integrate with Babylon Euphrates 0.5.0 devnet, you need to use the signet network.
+A Bitcoin node is required to run the Babylon BTC Staker program. You will need to import a private key with some BTC into the Bitcoin node. If you don't have one, you can generate a new account using OKX wallet and export the private key. To integrate with Babylon Euphrates 0.5.0 devnet, you need to use the Signet Bitcoin test network. You can get some signet BTC through faucets such as https://signetfaucet.com/.
 
 1. Copy the `.env.bitcoin.example` file to `.env.bitcoin` and set the variables
 
-    ```bash
-    cp .env.bitcoin.example .env.bitcoin
-    ```
+   ```bash
+   cp .env.bitcoin.example .env.bitcoin
+   ```
 
-    * The `NETWORK` variable can be either `regtest` or `signet`.
-    * The `BTC_PRIVKEY` variable must be a valid Bitcoin private key in WIF format.
+   - For the Babylon Euphrates integration, the `NETWORK` variable should be set as `signet`.
+   - The `BTC_PRIVKEY` variable must be a valid Bitcoin private key in WIF format.
 
 2. Start the Bitcoin node
 
-    ```bash
-    make start-bitcoin
-    ```
+   ```bash
+   make start-bitcoin
+   ```
 
 3. Verify the Bitcoin node is synced and has a balance
 
-    ```bash
-    make verify-bitcoin-sync-balance
-    ```
+   ```bash
+   make verify-bitcoin-sync-balance
+   ```
 
-    Note: this step may take ~10 minutes to complete.
+   Note: this step may take ~10 minutes to complete.
 
 If you want to check the Bitcoin node logs, you can run the following command:
 
@@ -68,15 +68,22 @@ If you want to stop the Bitcoin node (and remove the synced data), you can run t
     make stop-bitcoin
     ```
 
+## Upgrade OP-stack chain to support BTC staking
+
+To integrate with Babylon, you will need to upgrade your nodes to support BTC staking. To do so, replace `op-node` with Snapchain's [fork](https://hub.docker.com/r/babylonlabs/op-node-babylon-finality-gadget), available as a Docker image.
+
+If you are unsure how to do this, please refer to the [OP chain deployment](https://github.com/Snapchain/op-chain-deployment/blob/main/README.md) guide.
+
 ## Integrate Babylon finality system with OP-Stack chain
 
-This section describes how to integrate Babylon finality system to Babylon Euphrates 0.5.0 devnet with OP-Stack chain.
+This section describes how to integrate the Babylon finality system to your OP-Stack chain, using Babylon Euphrates 0.5.0 devnet.
 
-Before starting the following steps, please make sure:
+Before starting, please make sure:
 
-* your Bitcoin Signet node is synced and has a wallet that has signet BTC balance.
-* your OP-Stack chain is running and have at least one finalized block. For more details about how to setup an OP-Stack chain with BTC staking support, please refer to the [OP chain deployment](https://github.com/Snapchain/op-chain-deployment/blob/main/README.md) repo.
+- Your Bitcoin Signet node is synced and has a wallet with enough signet BTC balance (e.g. >0.01 BTC).
+- Your OP-Stack chain is running and has at least one finalized block. This is important because the Babylon fast finality gadget starts processing blocks from the (non-zero) finalized height.
 
+For more details about how to setup an OP-Stack chain with BTC staking support, please refer to the [OP chain deployment](https://github.com/Snapchain/op-chain-deployment/blob/main/README.md) repo.
 
 ### 1. Get some test BBN tokens from the Euphrates faucet
 
@@ -94,26 +101,38 @@ Copy the `.env.babylon-integration.example` file to `.env.babylon-integration`
 cp .env.babylon-integration.example .env.babylon-integration
 ```
 
-Replace the IP with your server's IP in the following variables:
-- `BITCOIN_RPC_HOST`: for the Bitcoin Signet node.
-- `ZMQ_RAWBLOCK_URL`: for the Bitcoin Signet node.
-- `ZMQ_RAWTX_URL`: for the Bitcoin Signet node.
-- `CONSUMER_EOTS_MANAGER_ADDRESS`
-- `FINALITY_GADGET_RPC`
-- `NEXT_PUBLIC_FINALITY_GADGET_API_URL`: for the finality explorer.
+The key env vars to set are the server IP addresses where your Bitcoin Signet node and Babylon finality system are deployed. Note that the ports are preconfigured in the Docker Compose files used for this deployment.
 
-Configure the following variables:
-- `BABYLON_PREFUNDED_KEY_MNEMONIC`: the mnemonic for the address you used to claim BBN tokens in the previous step.
-- `CONSUMER_ID`: this is the identifier for your OP-Stack chain registration on Babylon, you can set it to anything.
+- `BITCOIN_RPC_HOST`: the Bitcoin Signet node's IP address.
+- `ZMQ_RAWBLOCK_URL`: the Bitcoin Signet node's IP address.
+- `ZMQ_RAWTX_URL`: the Bitcoin Signet node's IP address.
+- `CONSUMER_EOTS_MANAGER_ADDRESS`: the Babylon finality system's IP address.
+- `FINALITY_GADGET_RPC`: the Babylon finality system's IP address.
+- `NEXT_PUBLIC_FINALITY_GADGET_API_URL`: the Babylon finality system's IP address.
+
+Besides these, you will need to set the following variables:
+
+- `BABYLON_PREFUNDED_KEY_MNEMONIC`: the mnemonic for the wallet you used to claim BBN tokens in the previous step.
+- `CONSUMER_ID`: this is the identifier for your OP-Stack chain registration on Babylon, you can set it to anything you want (the convention we use is `<chain_type>-<chain_name>-<chain_id>-<version>`, e.g. `op-stack-tohma-706114-0001`).
 - `CONSUMER_CHAIN_NAME`: this is a human-readable name for your chain.
 - `OP_FP_MONIKER`: this is a human-readable name for your OP-Stack chain's finality provider.
 - `L2_RPC_URL`: this is your OP-Stack chain's RPC URL.
 
 ### 3. Set Babylon keys
 
-This step imports the pre-funded Babylon key, which will be used to deploy cw contract, btc-staker, register OP-Stack chain, etc.
+This step imports the pre-funded Babylon key, which will be used to deploy the different components of the Babylon finality system:
 
-It also generates a new Babylon account for your OP-Stack chain's finality provider and funds it with the pre-funded Babylon account, because the finality provider needs to have some BBN tokens to pay for the gas fees for submitting finality votes.
+- CW contract: a CosmWasm smart contract deployed on BabylonChain that enables / disables the finality gadget and stores finality votes (i.e. provides DA) for your OP-stack chain.
+- BTC Staker: a peripheral program that creates the BTC delegation for your consumer FP, and communicates with Babylon node.
+- Consumer EOTS Manager: a service that manages generation and submission of EOTS signatures for your consumer FP.
+- Consumer Finality Provider: a service that manages consumer FPs and submits finality votes to the CW contract.
+
+The prefunded Babylon account is also used for key actions such as:
+
+1. Registering your OP-Stack consumer chain on Babylon.
+2. Generates a new account for your OP-Stack chain's finality provider and funding it with BBN tokens to pay for gas when submitting finality votes.
+
+Simply run:
 
 ```bash
 make set-babylon-keys
@@ -135,9 +154,11 @@ Deploy the finality contract for your OP-Stack chain. Finality votes are submitt
 make deploy-cw-contract
 ```
 
+Once deployed, the contract address is printed to your console and stored at `.deploy/contract/contract-address.txt`.
+
 ### 6. Start the Babylon BTC Staker
 
-Start the Babylon BTC Staker, used to create the BTC delegation for your OP-Stack chain finality provider.
+Start the Babylon BTC Staker, which isused to create the BTC delegation for your OP-Stack chain finality provider.
 
 ```bash
 make start-babylon-btc-staker
@@ -168,9 +189,9 @@ make start-finality-gadget
 
 ### 9. Enable the Finality Gadget on OP-Stack chain
 
-**Note:** This assumes your OP-Stack chain was deployed using the [OP chain deployment](https://github.com/Snapchain/op-chain-deployment/blob/main/README.md).
+**Note:** This assumes your OP-Stack chain was deployed using the [OP chain deployment](https://github.com/Snapchain/op-chain-deployment/blob/main/README.md). This step will only work if you are using Snapchain's fork of `op-node`.
 
-On the machine where your OP-Stack chain is deployed, update the `BBN_FINALITY_GADGET_RPC` (similar to `FINALITY_GADGET_RPC` above) in `.env` file.
+On the machine where your OP-Stack chain is deployed, update `BBN_FINALITY_GADGET_RPC` (similar to `FINALITY_GADGET_RPC` above) in `.env` file.
 
 Then restart the `op-node` service:
 
@@ -200,11 +221,19 @@ Once the BTC delegation is activated, set the `IS_ENABLED=true` in the `.env.bab
 make toggle-cw-killswitch
 ```
 
+This should set the `is_enabled` field to `true` in the CW contract. You can verify this by querying the `is_enabled` field:
+
+```bash
+babylond query wasm contract-state smart $CONTRACT_ADDR '{"is_enabled":{}}' --chain-id euphrates-0.5.0 --node https://rpc-euphrates.devnet.babylonlabs.io -o json
+```
+
 ### 12. Start the finality explorer
 
 ```bash
 make start-finality-explorer
 ```
+
+You should now be able to access the frontend at `http://<your-server-ip>:13000` and monitor the finality status of your OP-Stack chain.
 
 ### 13. Verify the integration
 

--- a/README.md
+++ b/README.md
@@ -120,19 +120,10 @@ Besides these, you will need to set the following variables:
 
 ### 3. Set Babylon keys
 
-This step imports the pre-funded Babylon key, which will be used to deploy the different components of the Babylon finality system:
-
-- CW contract: a CosmWasm smart contract deployed on BabylonChain that enables / disables the finality gadget and stores finality votes (i.e. provides DA) for your OP-stack chain.
-- BTC Staker: a peripheral program that creates the BTC delegation for your consumer FP, and communicates with Babylon node.
-- Consumer EOTS Manager: a service that manages generation and submission of EOTS signatures for your consumer FP.
-- Consumer Finality Provider: a service that manages consumer FPs and submits finality votes to the CW contract.
-
-The prefunded Babylon account is also used for key actions such as:
-
-1. Registering your OP-Stack consumer chain on Babylon.
-2. Generates a new account for your OP-Stack chain's finality provider and funding it with BBN tokens to pay for gas when submitting finality votes.
-
-Simply run:
+This step
+- imports the pre-funded Babylon key, which will be used to deploy the finality contract, register your finality provider, create BTC delegation in later steps.
+- generates a new account for your OP-Stack chain's finality provider.
+- funds it with the pre-funded Babylon account, to pay for gas fees when submitting finality votes.
 
 ```bash
 make set-babylon-keys
@@ -158,7 +149,7 @@ Once deployed, the contract address is printed to your console and stored at `.d
 
 ### 6. Start the Babylon BTC Staker
 
-Start the Babylon BTC Staker, which isused to create the BTC delegation for your OP-Stack chain finality provider.
+Start the Babylon BTC Staker, which is used to create the BTC delegation for your OP-Stack chain finality provider.
 
 ```bash
 make start-babylon-btc-staker

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ If you want to stop the Bitcoin node (and remove the synced data), you can run t
     make stop-bitcoin
     ```
 
-## Integrate Babylon finality system with OP Stack chain
+## Integrate Babylon finality system with OP-Stack chain
 
-This section describes how to integrate Babylon finality system to Babylon Euphrates 0.5.0 devnet with OP Stack chain.
+This section describes how to integrate Babylon finality system to Babylon Euphrates 0.5.0 devnet with OP-Stack chain.
 
 Before starting the following steps, please make sure:
 
 * your Bitcoin Signet node is synced and has a wallet that has signet BTC balance.
-* your OP Stack chain is running and have at least one finalized block. For more details about how to setup an OP Stack chain with BTC staking support, please refer to the [OP chain deployment](https://github.com/Snapchain/op-chain-deployment/blob/main/README.md) repo.
+* your OP-Stack chain is running and have at least one finalized block. For more details about how to setup an OP-Stack chain with BTC staking support, please refer to the [OP chain deployment](https://github.com/Snapchain/op-chain-deployment/blob/main/README.md) repo.
 
 
 ### 1. Get some test BBN tokens from the Euphrates faucet
@@ -94,88 +94,63 @@ Copy the `.env.babylon-integration.example` file to `.env.babylon-integration`
 cp .env.babylon-integration.example .env.babylon-integration
 ```
 
-**Configure for Bitcoin**
-
-Based on the previous step `Setup Bitcoin node`, set the following variables with the values:
-- `BITCOIN_RPC_PASS`
-- `BTC_WALLET_PASS`
-    
-and replace the IP with your Bitcoin node IP:
-- `BITCOIN_RPC_HOST`
-- `ZMQ_RAWBLOCK_URL`
-- `ZMQ_RAWTX_URL`
-
-**Configure for Babylon**
-
-set your Babylon key's mnemonic, the address should have some BBN tokens, it will be used in the following steps
-
-- `BABYLON_PREFUNDED_KEY_MNEMONIC`
-
-set the following variables to register your OP Stack chain to Babylon:
-
-- `CONSUMER_ID`
-- `CONSUMER_CHAIN_NAME`
-
-set your OP Stack chain's finality provider moniker
-
-- `OP_FP_MONIKER`
-
-replace the IP with the Babylon finality system you deployed server IP:
-
+Replace the IP with your server's IP in the following variables:
+- `BITCOIN_RPC_HOST`: for the Bitcoin Signet node.
+- `ZMQ_RAWBLOCK_URL`: for the Bitcoin Signet node.
+- `ZMQ_RAWTX_URL`: for the Bitcoin Signet node.
 - `CONSUMER_EOTS_MANAGER_ADDRESS`
 - `FINALITY_GADGET_RPC`
 
-**Configure for OP Stack chain**
+Configure the following variables:
+- `BABYLON_PREFUNDED_KEY_MNEMONIC`: the mnemonic for the address you used to claim BBN tokens in the previous step.
+- `CONSUMER_ID`: this is the identifier for your OP-Stack chain registration on Babylon, you can set it to anything.
+- `CONSUMER_CHAIN_NAME`: this is a human-readable name for your chain.
+- `OP_FP_MONIKER`: this is a human-readable name for your OP-Stack chain's finality provider.
+- `L2_RPC_URL`: this is your OP-Stack chain's RPC URL.
 
-set your OP Stack chain's RPC URL
+### 3. Set Babylon keys
 
-- `L2_RPC_URL`
+This step imports the pre-funded Babylon key, which will be used to deploy cw contract, btc-staker, register OP-Stack chain, etc.
 
-### 2. Set Babylon keys
-
-Set the pre-funded Babylon key, used to deploy cw contract, btc-staker, register OP Stack chain, etc. 
-
-Also, generate a new Babylon account for your OP Stack chain's finality provider and fund it with the previously imported pre-funded Babylon account.
+It also generates a new Babylon account for your OP-Stack chain's finality provider and funds it with the pre-funded Babylon account, because the finality provider needs to have some BBN tokens to pay for the gas fees for submitting finality votes.
 
 ```bash
 make set-babylon-keys
 ```
 
-### 3. Register OP Stack chain
+### 4. Register OP-Stack chain
 
-Register your OP Stack chain to Babylon.
+Register your OP-Stack chain to Babylon.
 
 ```bash
 make register-consumer-chain
 ```
 
-### 4. Deploy finality contract
+### 5. Deploy finality contract
 
-Deploy the finality contract for your OP Stack chain.
+Deploy the finality contract for your OP-Stack chain. Finality votes are submitted to this contract.
 
 ```bash
 make deploy-cw-contract
 ```
 
-### 5. Start the Babylon BTC Staker
+### 6. Start the Babylon BTC Staker
 
-Start the Babylon BTC Staker, used to create the BTC delegation for your OP Stack chain finality provider.
+Start the Babylon BTC Staker, used to create the BTC delegation for your OP-Stack chain finality provider.
 
 ```bash
 make start-babylon-btc-staker
 ```
 
-### 6. Start the EOTS Manager
+### 7. Start the EOTS Manager and Finality Provider
 
-Start the EOTS Manager for your OP Stack chain finality provider.
+Start the EOTS Manager for your OP-Stack chain finality provider.
 
 ```bash
 make start-consumer-eotsmanager
 ```
 
-### 7. Start the Finality Provider
-
-Start your OP Stack chain's Finality Provider, and then register it to Babylon.
+Start your OP-Stack chain's Finality Provider, and then register it to Babylon.
 
 ```bash
 make start-consumer-finality-provider
@@ -184,23 +159,19 @@ make register-op-consumer-fp
 
 ### 8. Start the Finality Gadget
 
-Start the Finality Gadget, which provides the query interface for BTC finalized status of your OP Stack chain's blocks.
+Start the Finality Gadget, which provides the query interface for BTC finalized status of your OP-Stack chain's blocks.
 
 ```bash
 make start-finality-gadget
 ```
 
-### 9. Restart OP Stack chain node
+### 9. Enable the Finality Gadget on OP-Stack chain
 
-**Note:** This assumes your OP Stack chain was deployed using the [OP chain deployment](https://github.com/Snapchain/op-chain-deployment/blob/main/README.md) on a different server.
+**Note:** This assumes your OP-Stack chain was deployed using the [OP chain deployment](https://github.com/Snapchain/op-chain-deployment/blob/main/README.md).
 
-Now login into your OP Stack chain server, update the `BBN_FINALITY_GADGET_RPC` with the Finality Gadget's gRPC(e.g `<your-server-ip>:50051`) in `.env` file.
+On the machine where your OP-Stack chain is deployed, update the `BBN_FINALITY_GADGET_RPC` (similar to `FINALITY_GADGET_RPC` above) in `.env` file.
 
-```bash
-BBN_FINALITY_GADGET_RPC=<FINALITY_GADGET_RPC>
-```
-
-And then restart the `op-node` service, run:
+Then restart the `op-node` service:
 
 ```bash
 make l2-op-node-restart
@@ -208,13 +179,13 @@ make l2-op-node-restart
 
 ### 10. Create BTC delegation and wait for activation
 
-Create the BTC delegation for your OP Stack chain finality provider.
+Create the BTC delegation for your OP-Stack chain's finality provider.
 
 ```bash
 make create-btc-delegation
 ```
 
-Wait for the delegation activation, which takes about 3 BTC blocks, and then you can check the delegation status by the following command:
+Wait for the delegation activation, which takes about 3 BTC blocks. You can check the delegation status by the following command:
 
 ```bash
 make check-btc-delegation


### PR DESCRIPTION
## Summary

for the hacker house.

note, we need to merge `https://github.com/Snapchain/op-chain-deployment/pull/32` to fix `make l2-op-node-restart`

a few improvements we can make:

- we can configure `NEXT_PUBLIC_FINALITY_GADGET_API_URL` early in Ansible instead of manually set it later before running finality explorer
- we can use ansible to start finality explorer right after FG is up (before it's enabled) b/c it's stateless web app
- we should do `make toggle-cw-killswitch ENABLED=<true or false>` instead of have the make cmd relying on the .env file

## Test Plan

cross-reference the devops ansible playbook and the notion doc to make sure the steps are correct