### PR TITLE
chore: update for fp keyring

### DIFF
--- a/docker/docker-compose-babylon-integration.yml
+++ b/docker/docker-compose-babylon-integration.yml
@@ -7,6 +7,7 @@ services:
       - "${PWD}/.env.babylon-integration"
     volumes:
       - ${PWD}/.deploy/babylond:/home/.babylond
+      - ${PWD}/.consumer-finality-provider:/home/.consumer-finality-provider
     entrypoint:
       - /bin/bash
       - -c
@@ -60,6 +61,7 @@ services:
       - "${PWD}/.env.babylon-integration"
     volumes:
       - ${PWD}/.deploy/babylond:/home/.babylond
+      - ${PWD}/.consumer-finality-provider:/home/.consumer-finality-provider
     entrypoint:
       - /bin/bash
       - -c

--- a/scripts/babylon-integration/start-consumer-finality-provider.sh
+++ b/scripts/babylon-integration/start-consumer-finality-provider.sh
@@ -9,39 +9,35 @@ set +a
 EXAMPLE_FINALITY_PROVIDER_CONF=$(pwd)/configs/babylon-integration/consumer-fpd.conf
 CONSUMER_FINALITY_PROVIDER_DIR=$(pwd)/.consumer-finality-provider
 FINALITY_PROVIDER_CONF=$(pwd)/.consumer-finality-provider/fpd.conf
-CONSUMER_FP_KEYRING_DIR=$(pwd)/.deploy/babylond/$CONSUMER_FINALITY_PROVIDER_KEY
 
-if [ ! -d "$CONSUMER_FINALITY_PROVIDER_DIR" ]; then
-  echo "Creating $CONSUMER_FINALITY_PROVIDER_DIR directory..."
-  mkdir -p $CONSUMER_FINALITY_PROVIDER_DIR
-
-  echo "Copying $EXAMPLE_FINALITY_PROVIDER_CONF to $FINALITY_PROVIDER_CONF..."
-  cp $EXAMPLE_FINALITY_PROVIDER_CONF $FINALITY_PROVIDER_CONF
-
-  # for finality provider, replace placeholders with env variables
-  sed -i.bak "s|\${CONSUMER_EOTS_MANAGER_ADDRESS}|$CONSUMER_EOTS_MANAGER_ADDRESS|g" $FINALITY_PROVIDER_CONF
-  sed -i.bak "s|\${BITCOIN_NETWORK}|$BITCOIN_NETWORK|g" $FINALITY_PROVIDER_CONF
-  sed -i.bak "s|\${CONSUMER_FINALITY_PROVIDER_KEY}|$CONSUMER_FINALITY_PROVIDER_KEY|g" $FINALITY_PROVIDER_CONF
-  sed -i.bak "s|\${L2_RPC_URL}|$L2_RPC_URL|g" $FINALITY_PROVIDER_CONF
-  sed -i.bak "s|\${L2_BLOCK_TIME}|$L2_BLOCK_TIME|g" $FINALITY_PROVIDER_CONF
-  sed -i.bak "s|\${FINALITY_GADGET_RPC}|$FINALITY_GADGET_RPC|g" $FINALITY_PROVIDER_CONF
-  sed -i.bak "s|\${FINALITY_GADGET_ADDRESS}|$FINALITY_GADGET_ADDRESS|g" $FINALITY_PROVIDER_CONF
-  sed -i.bak "s|\${BABYLON_CHAIN_ID}|$BABYLON_CHAIN_ID|g" $FINALITY_PROVIDER_CONF
-  sed -i.bak "s|\${BABYLON_RPC_URL}|$BABYLON_RPC_URL|g" $FINALITY_PROVIDER_CONF
-  sed -i.bak "s|\${BABYLON_GRPC_URL}|$BABYLON_GRPC_URL|g" $FINALITY_PROVIDER_CONF
-  rm $CONSUMER_FINALITY_PROVIDER_DIR/fpd.conf.bak
-  echo "Successfully updated the conf file $FINALITY_PROVIDER_CONF"
-
-  # Copy the finality provider key to the mounted .consumer-finality-provider directory
-  cp -R $CONSUMER_FP_KEYRING_DIR/keyring-test $CONSUMER_FINALITY_PROVIDER_DIR/
-  echo "Copied the generated key to the $CONSUMER_FINALITY_PROVIDER_DIR directory"
-
-  # the folders are owned by user snapchain. but per https://github.com/babylonlabs-io/finality-provider/blob/c02f046587db569d550f63ed776ba05735728b01/Dockerfile#L40,
-  # it needs to be writable by user 1138. so we need the permission.
-  chmod -R 777 $CONSUMER_FINALITY_PROVIDER_DIR
-  echo "Successfully initialized $CONSUMER_FINALITY_PROVIDER_DIR directory"
-  echo
+# Check if the finality provider key exists in the mounted .consumer-finality-provider directory
+if ! babylond keys show $CONSUMER_FINALITY_PROVIDER_KEY --keyring-dir $CONSUMER_FINALITY_PROVIDER_DIR --keyring-backend test &> /dev/null; then
+  echo "The finality provider key $CONSUMER_FINALITY_PROVIDER_KEY does not exist in directory $CONSUMER_FINALITY_PROVIDER_DIR"
+  exit 1
 fi
+
+echo "Copying $EXAMPLE_FINALITY_PROVIDER_CONF to $FINALITY_PROVIDER_CONF..."
+cp $EXAMPLE_FINALITY_PROVIDER_CONF $FINALITY_PROVIDER_CONF
+
+# for finality provider, replace placeholders with env variables
+sed -i.bak "s|\${CONSUMER_EOTS_MANAGER_ADDRESS}|$CONSUMER_EOTS_MANAGER_ADDRESS|g" $FINALITY_PROVIDER_CONF
+sed -i.bak "s|\${BITCOIN_NETWORK}|$BITCOIN_NETWORK|g" $FINALITY_PROVIDER_CONF
+sed -i.bak "s|\${CONSUMER_FINALITY_PROVIDER_KEY}|$CONSUMER_FINALITY_PROVIDER_KEY|g" $FINALITY_PROVIDER_CONF
+sed -i.bak "s|\${L2_RPC_URL}|$L2_RPC_URL|g" $FINALITY_PROVIDER_CONF
+sed -i.bak "s|\${L2_BLOCK_TIME}|$L2_BLOCK_TIME|g" $FINALITY_PROVIDER_CONF
+sed -i.bak "s|\${FINALITY_GADGET_RPC}|$FINALITY_GADGET_RPC|g" $FINALITY_PROVIDER_CONF
+sed -i.bak "s|\${FINALITY_GADGET_ADDRESS}|$FINALITY_GADGET_ADDRESS|g" $FINALITY_PROVIDER_CONF
+sed -i.bak "s|\${BABYLON_CHAIN_ID}|$BABYLON_CHAIN_ID|g" $FINALITY_PROVIDER_CONF
+sed -i.bak "s|\${BABYLON_RPC_URL}|$BABYLON_RPC_URL|g" $FINALITY_PROVIDER_CONF
+sed -i.bak "s|\${BABYLON_GRPC_URL}|$BABYLON_GRPC_URL|g" $FINALITY_PROVIDER_CONF
+rm $CONSUMER_FINALITY_PROVIDER_DIR/fpd.conf.bak
+echo "Successfully updated the conf file $FINALITY_PROVIDER_CONF"
+
+# the folders are owned by user snapchain. but per https://github.com/babylonlabs-io/finality-provider/blob/c02f046587db569d550f63ed776ba05735728b01/Dockerfile#L40,
+# it needs to be writable by user 1138. so we need the permission.
+chmod -R 777 $CONSUMER_FINALITY_PROVIDER_DIR
+echo "Successfully initialized $CONSUMER_FINALITY_PROVIDER_DIR directory"
+echo
 
 echo "Starting consumer-finality-provider..."
 docker compose -f docker/docker-compose-babylon-integration.yml up -d consumer-finality-provider

--- a/scripts/babylon-integration/utils/set-babylon-keys.sh
+++ b/scripts/babylon-integration/utils/set-babylon-keys.sh
@@ -5,9 +5,16 @@ set -euo pipefail
 echo "Setting Babylon keys..."
 # Set keyring directory
 KEYRING_DIR=/home/.babylond
+CONSUMER_FP_KEYRING_DIR=/home/.consumer-finality-provider
+
 if [ ! -d "$KEYRING_DIR" ]; then
-    echo "Creating directory $KEYRING_DIR"
+    echo "Creating prefunded keyring directory $KEYRING_DIR"
     mkdir -p $KEYRING_DIR
+fi
+
+if [ ! -d "$CONSUMER_FP_KEYRING_DIR" ]; then
+    echo "Creating consumer-finality-provider keyring directory $CONSUMER_FP_KEYRING_DIR"
+    mkdir -p $CONSUMER_FP_KEYRING_DIR
 fi
 
 # Import the Babylon prefunded key
@@ -22,10 +29,7 @@ fi
 echo
 
 # Create new Babylon account for the consumer-finality-provider
-CONSUMER_FP_KEYRING_DIR=$KEYRING_DIR/$CONSUMER_FINALITY_PROVIDER_KEY
 if ! babylond keys show $CONSUMER_FINALITY_PROVIDER_KEY --keyring-dir $CONSUMER_FP_KEYRING_DIR --keyring-backend test &> /dev/null; then
-    echo "Creating keyring directory $CONSUMER_FP_KEYRING_DIR"
-    mkdir -p $CONSUMER_FP_KEYRING_DIR
     echo "Creating key $CONSUMER_FINALITY_PROVIDER_KEY..."
     babylond keys add $CONSUMER_FINALITY_PROVIDER_KEY \
         --keyring-dir $CONSUMER_FP_KEYRING_DIR \

--- a/scripts/babylon-integration/utils/teardown.sh
+++ b/scripts/babylon-integration/utils/teardown.sh
@@ -5,8 +5,8 @@ source "./common.sh"
 
 # Get the consumer FP address
 KEYRING_DIR=/home/.babylond
-CONSUMER_FP_KEYRING_DIR=$KEYRING_DIR/$CONSUMER_FINALITY_PROVIDER_KEY
-CONSUMER_FP_ADDRESS=$(babylond keys show -a consumer-finality-provider \
+CONSUMER_FP_KEYRING_DIR=/home/.consumer-finality-provider
+CONSUMER_FP_ADDRESS=$(babylond keys show -a $CONSUMER_FINALITY_PROVIDER_KEY \
     --keyring-dir $CONSUMER_FP_KEYRING_DIR \
     --keyring-backend test)
 echo "Consumer FP address: $CONSUMER_FP_ADDRESS"


### PR DESCRIPTION
## Summary

This PR updates the fp keyring folder:
* directly create the fp dir and generate fp key under it in `set-babylon-keys.sh`
* remove the cp keyring folder in `start-consumer-finality-provider.sh`
* change the teardown script based this change

## Test Plan

TODO: it will be tested on new deployment