### PR TITLE
fix: consumer chain registration error

### DIFF
--- a/scripts/babylon-integration/utils/register-consumer-chain.sh
+++ b/scripts/babylon-integration/utils/register-consumer-chain.sh
@@ -37,3 +37,25 @@ CONSUMER_REGISTRATION_TX_HASH=$(babylond tx btcstkconsumer register-consumer \
     | jq -r '.txhash')
 echo "Consumer registration transaction hash: $CONSUMER_REGISTRATION_TX_HASH"
 echo
+
+# wait for the transaction to be included in a block
+echo "Waiting for the transaction to be included in a block..."
+wait_for_tx "$CONSUMER_REGISTRATION_TX_HASH" 10 5
+
+# check chain registered
+echo "Checking if the chain is registered..."
+
+# query all registered consumer chains
+echo "Querying all registered consumer chains..."
+CONSUMER_IDS=$(babylond query btcstkconsumer registered-consumers \
+    --chain-id $BABYLON_CHAIN_ID \
+    --node $BABYLON_RPC_URL \
+    -o json | jq -r '.consumer_ids[]')
+
+# check if the consumer chain is registered, if not exit with error
+if echo "$CONSUMER_IDS" | grep -q "^${CONSUMER_ID}$"; then
+    echo "Consumer chain $CONSUMER_ID successfully registered"
+else
+    echo "Consumer chain $CONSUMER_ID failed to register"
+    exit 1
+fi

--- a/scripts/babylon-integration/utils/register-consumer-chain.sh
+++ b/scripts/babylon-integration/utils/register-consumer-chain.sh
@@ -21,7 +21,7 @@ fi
 # TODO: for now, we can use the consumer chain name as the consumer description,
 # remove it after issue #255 (https://github.com/babylonlabs-io/babylon/issues/255) is fixed
 echo "Registering consumer chain $CONSUMER_ID..."
-CONSUMER_REGISTRATION_TX_HASH=$(babylond tx btcstkconsumer register-consumer \
+CONSUMER_REGISTRATION_OUTPUT=$(babylond tx btcstkconsumer register-consumer \
     "$CONSUMER_ID" \
     "$CONSUMER_CHAIN_NAME" \
     "$CONSUMER_CHAIN_NAME" \
@@ -33,8 +33,11 @@ CONSUMER_REGISTRATION_TX_HASH=$(babylond tx btcstkconsumer register-consumer \
     --gas-prices 0.2ubbn \
     --gas auto \
     --gas-adjustment 2 \
-    -o json -y \
-    | jq -r '.txhash')
+    -o json -y)
+echo "$CONSUMER_REGISTRATION_OUTPUT"
+echo
+
+CONSUMER_REGISTRATION_TX_HASH=$(echo "$CONSUMER_REGISTRATION_OUTPUT" | jq -r '.txhash')
 echo "Consumer registration transaction hash: $CONSUMER_REGISTRATION_TX_HASH"
 echo
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the consumer chain registration fails quietly and exits without error. This breaks the later steps of the deployment script.

```
Querying all registered consumer chains...
Registering consumer chain op-stack-tohma-706114-0007...
Error: rpc error: code = Unknown desc = rpc error: code = Unknown desc = account sequence mismatch, expected 7979, got 7978: incorrect account sequence [cosmos/cosmos-sdk@v0.50.9/x/auth/ante/sigverify.go:290] with gas used: '16556': unknown request
Usage:
  babylond tx btcstkconsumer register-consumer <consumer-id> <name> [description] [flags]
```

## Test plan

Run Babylon finality system Ansible script, or the specific step:

```
ansible-playbook -i ini/babylon.ini playbooks/debian_op_babylon_devnet_finality_system.yml

make register-consumer-chain
```