### PR TITLE
fix: check consumer fp key

### DIFF
--- a/scripts/babylon-integration/start-consumer-finality-provider.sh
+++ b/scripts/babylon-integration/start-consumer-finality-provider.sh
@@ -11,7 +11,7 @@ CONSUMER_FINALITY_PROVIDER_DIR=$(pwd)/.consumer-finality-provider
 FINALITY_PROVIDER_CONF=$(pwd)/.consumer-finality-provider/fpd.conf
 
 # Check if the finality provider key exists in the mounted .consumer-finality-provider directory
-if ! babylond keys show $CONSUMER_FINALITY_PROVIDER_KEY --keyring-dir $CONSUMER_FINALITY_PROVIDER_DIR --keyring-backend test &> /dev/null; then
+if [ ! -f "$CONSUMER_FINALITY_PROVIDER_DIR/keyring-test/$CONSUMER_FINALITY_PROVIDER_KEY.info" ]; then
   echo "The finality provider key $CONSUMER_FINALITY_PROVIDER_KEY does not exist in directory $CONSUMER_FINALITY_PROVIDER_DIR"
   exit 1
 fi


### PR DESCRIPTION
## Summary

This PR fixes the consumer FP key check issue by updating it to check whether the consumer FP key file exists instead. Since `babylond` is no longer installed on the server during deployment, the previous check would always fail.

![image](https://github.com/user-attachments/assets/5792cffb-fd18-478a-84ff-18365d1d59e7)


## Test Plan

we can only manually run the scripts to test it.

case 1, directly run the script, it should fail the check with the error:
```
make start-consumer-finality-provider
                                                                        
The finality provider key consumer-finality-provider does not exist in directory /Users/lyy/snapchain/babylon-deployment/.consumer-finality-provider
make: *** [start-consumer-finality-provider] Error 1
```

case2, run the script after setting the Babylon keys, it should pass the check.
* temporarily comment out the fund step(line 42) in the `set-babylon-keys.sh` script and start FP step(line 42) in the `start-consumer-finality-provider.sh` script
* temporarily build a test docker image and set the `set-babylon-keys` service with the image tag `test` in the `docker-compose-babylon-integration.yml`

```
docker build --tag snapchain/babylon-deployment-utils:test -f ./scripts/babylon-integration/utils/Dockerfile ./scripts/babylon-integration/utils

make set-babylon-keys
make start-consumer-finality-provider

Copying /Users/lyy/snapchain/babylon-deployment/configs/babylon-integration/consumer-fpd.conf to /Users/lyy/snapchain/babylon-deployment/.consumer-finality-provider/fpd.conf...
Successfully updated the conf file /Users/lyy/snapchain/babylon-deployment/.consumer-finality-provider/fpd.conf
Successfully initialized /Users/lyy/snapchain/babylon-deployment/.consumer-finality-provider directory
```

**Note**: After the testing, remember to revert the temporarily updated files: 
* scripts/babylon-integration/utils/set-babylon-keys.sh
* scripts/babylon-integration/start-consumer-finality-provider.sh
* docker/docker-compose-babylon-integration.yml.

