### PR TITLE
chore: change the value of `MinRandHeightGap` in FP config

### DIFF
--- a/configs/babylon-integration/consumer-fpd.conf
+++ b/configs/babylon-integration/consumer-fpd.conf
@@ -12,7 +12,7 @@ NumPubRand = 100
 NumPubRandMax = 1000
 
 ; The minimum gap between the last committed rand height and the current OP L2 block height
-MinRandHeightGap = 10
+MinRandHeightGap = 10000
 
 ; The interval between each update of finality-provider status
 StatusUpdateInterval = 5s

--- a/configs/babylon-integration/consumer-fpd.conf
+++ b/configs/babylon-integration/consumer-fpd.conf
@@ -12,7 +12,7 @@ NumPubRand = 100
 NumPubRandMax = 1000
 
 ; The minimum gap between the last committed rand height and the current OP L2 block height
-MinRandHeightGap = 10000
+MinRandHeightGap = 10100
 
 ; The interval between each update of finality-provider status
 StatusUpdateInterval = 5s

--- a/configs/babylon-integration/consumer-fpd.conf
+++ b/configs/babylon-integration/consumer-fpd.conf
@@ -12,7 +12,7 @@ NumPubRand = 100
 NumPubRandMax = 1000
 
 ; The minimum gap between the last committed rand height and the current OP L2 block height
-MinRandHeightGap = 10100
+MinRandHeightGap = 11000
 
 ; The interval between each update of finality-provider status
 StatusUpdateInterval = 5s


### PR DESCRIPTION
## Summary

This small PR updates the value of [MinRandHeightGap](https://github.com/babylonlabs-io/finality-provider/blob/main/docs/commit-pub-rand.md#determining-minrandheightgap) b/c it must account for BTC-timestamping delays.

For the OP L2 with a block time of 6s, Babylon's BTC-timestamping requires 100 BTC blocks for epoch finalization. Therefore, the value of `MinRandHeightGap` should be > 10,000 to ensure pub randomness is always available.

## Test Plan

N/A