### PR TITLE
feat: add proxy-setup.sh

### DIFF
--- a/.env.babylon-integration.example
+++ b/.env.babylon-integration.example
@@ -65,3 +65,17 @@ STAKING_AMOUNT=10000 # 0.0001 BTC
 
 # Finality Explorer Configuration
 NEXT_PUBLIC_FINALITY_GADGET_API_URL=http://11.22.33.44:18080
+
+# Cloudflare Configuration
+FINALITY_SYSTEM_SERVER_IP=11.22.33.44
+CLOUDFLARE_AUTH_EMAIL=<your-email@example.com>
+# 1. Log into Cloudflare dashboard
+# 2. Go to "My Profile" (top right)
+# 3. Scroll to "API Tokens"
+# 4. View your "Global API Key"
+CLOUDFLARE_API_KEY=<your-api-key>
+# 1. Log into Cloudflare dashboard
+# 2. Select your domain
+# 3. Look in the right sidebar - "Zone ID" is listed there
+CLOUDFLARE_ZONE_ID=<your-zone-id>
+CLOUDFLARE_DNS_SUBDOMAIN=tohma

--- a/.env.babylon-integration.example
+++ b/.env.babylon-integration.example
@@ -66,7 +66,7 @@ STAKING_AMOUNT=10000 # 0.0001 BTC
 # Finality Explorer Configuration
 NEXT_PUBLIC_FINALITY_GADGET_API_URL=http://11.22.33.44:18080
 
-# Cloudflare Configuration
+# DNS Configuration
 FINALITY_SYSTEM_SERVER_IP=11.22.33.44
 CLOUDFLARE_AUTH_EMAIL=<your-email@example.com>
 # 1. Log into Cloudflare dashboard
@@ -79,3 +79,5 @@ CLOUDFLARE_API_KEY=<your-api-key>
 # 3. Look in the right sidebar - "Zone ID" is listed there
 CLOUDFLARE_ZONE_ID=<your-zone-id>
 CLOUDFLARE_DNS_SUBDOMAIN=tohma
+CERTBOT_EMAIL=support@snapchain.dev
+CERTBOT_DOMAIN_SUFFIX=tohma.snapchain.dev

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,6 @@ teardown:
 	@./scripts/babylon-integration/teardown.sh
 .PHONY: teardown
 
-dns-setup:
-	@./scripts/babylon-integration/dns-setup.sh
-.PHONY: dns-setup
+proxy-setup:
+	@./scripts/babylon-integration/proxy-setup.sh
+.PHONY: proxy-setup

--- a/Makefile
+++ b/Makefile
@@ -101,3 +101,7 @@ toggle-cw-killswitch:
 teardown:
 	@./scripts/babylon-integration/teardown.sh
 .PHONY: teardown
+
+dns-setup:
+	@./scripts/babylon-integration/dns-setup.sh
+.PHONY: dns-setup

--- a/configs/nginx/demo-app.conf.template
+++ b/configs/nginx/demo-app.conf.template
@@ -5,8 +5,21 @@ server {
     ssl_certificate /etc/letsencrypt/live/${CERTBOT_DOMAIN_SUFFIX}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/${CERTBOT_DOMAIN_SUFFIX}/privkey.pem;
 
+    # Backend API
+    location /api/ {
+        proxy_pass http://localhost:8000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Frontend
     location / {
-        proxy_pass http://localhost:3000; # replace host as needed
+        proxy_pass http://localhost:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/configs/nginx/demo-app.conf.template
+++ b/configs/nginx/demo-app.conf.template
@@ -1,0 +1,16 @@
+server {
+    listen 443 ssl;
+    server_name demo.${CERTBOT_DOMAIN_SUFFIX};
+
+    ssl_certificate /etc/letsencrypt/live/${CERTBOT_DOMAIN_SUFFIX}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${CERTBOT_DOMAIN_SUFFIX}/privkey.pem;
+
+    location / {
+        proxy_pass http://localhost:3000; # replace host as needed
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/configs/nginx/finality-explorer.conf.template
+++ b/configs/nginx/finality-explorer.conf.template
@@ -1,0 +1,16 @@
+server {
+    listen 443 ssl;
+    server_name finality.${CERTBOT_DOMAIN_SUFFIX};
+
+    ssl_certificate /etc/letsencrypt/live/${CERTBOT_DOMAIN_SUFFIX}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${CERTBOT_DOMAIN_SUFFIX}/privkey.pem;
+
+    location / {
+        proxy_pass http://localhost:13000; # replace host as needed
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/configs/nginx/finality-gadget-rpc.conf.template
+++ b/configs/nginx/finality-gadget-rpc.conf.template
@@ -1,0 +1,37 @@
+server {
+    listen 443 ssl;
+    server_name finality-rpc.${CERTBOT_DOMAIN_SUFFIX};
+
+    ssl_certificate /etc/letsencrypt/live/${CERTBOT_DOMAIN_SUFFIX}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${CERTBOT_DOMAIN_SUFFIX}/privkey.pem;
+
+    location / {
+        proxy_pass http://localhost:18080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+
+        # prevent duplicate headers by resetting existing ones
+        proxy_hide_header 'Access-Control-Allow-Origin';
+        proxy_hide_header 'Access-Control-Allow-Methods';
+        proxy_hide_header 'Access-Control-Allow-Headers';
+
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' $http_origin always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+            add_header 'Access-Control-Max-Age' 1728000 always;
+            add_header 'Content-Type' 'text/plain charset=UTF-8' always;
+            add_header 'Content-Length' 0 always;
+            return 204;
+        }
+
+        # this line is needed to prevent CORS errors
+        add_header 'Access-Control-Allow-Origin' $http_origin always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+        add_header 'Access-Control-Allow-Credentials' 'true' always;
+    }
+}

--- a/scripts/babylon-integration/dns-setup.sh
+++ b/scripts/babylon-integration/dns-setup.sh
@@ -33,5 +33,14 @@ create_dns_records() {
         }"
 }
 
-# finality gadget RPC, demo app, finality explorer
+# 1. create the DNS records for the subdomains
+# (finality gadget RPC, demo app, finality explorer)
 create_dns_records "finality-rpc" "demo" "finality"
+
+# 2. obtain the SSL certificate for each subdomain
+# the certs and keys will be stored in /etc/letsencrypt/live/
+# reference: https://eff-certbot.readthedocs.io/en/latest/using.html
+sudo certbot certonly --nginx --non-interactive --agree-tos -m ${CERTBOT_EMAIL} \
+  -d finality-rpc.${CERTBOT_DOMAIN_SUFFIX} \
+  -d demo.${CERTBOT_DOMAIN_SUFFIX} \
+  -d finality.${CERTBOT_DOMAIN_SUFFIX}

--- a/scripts/babylon-integration/dns-setup.sh
+++ b/scripts/babylon-integration/dns-setup.sh
@@ -38,7 +38,11 @@ create_dns_records() {
 create_dns_records "finality-rpc" "demo" "finality"
 
 # 2. obtain the SSL certificate for each subdomain
-# the certs will be stored in /etc/letsencrypt/live/ in a single file
+# the certs will be stored in /etc/letsencrypt/live/${CERTBOT_DOMAIN_SUFFIX}
+# 
+# note that Certbot creates a single certificate that's valid for all those 
+# domains (called a SAN - Subject Alternative Names certificate)
+# 
 # after running the command, you can verify by:
 #   sudo openssl x509 -in /etc/letsencrypt/live/${CERTBOT_DOMAIN_SUFFIX}/fullchain.pem -text | grep DNS:
 # 

--- a/scripts/babylon-integration/dns-setup.sh
+++ b/scripts/babylon-integration/dns-setup.sh
@@ -38,9 +38,13 @@ create_dns_records() {
 create_dns_records "finality-rpc" "demo" "finality"
 
 # 2. obtain the SSL certificate for each subdomain
-# the certs and keys will be stored in /etc/letsencrypt/live/
+# the certs will be stored in /etc/letsencrypt/live/ in a single file
+# after running the command, you can verify by:
+#   sudo openssl x509 -in /etc/letsencrypt/live/${CERTBOT_DOMAIN_SUFFIX}/fullchain.pem -text | grep DNS:
+# 
 # reference: https://eff-certbot.readthedocs.io/en/latest/using.html
 sudo certbot certonly --nginx --non-interactive --agree-tos -m ${CERTBOT_EMAIL} \
+  --cert-name ${CERTBOT_DOMAIN_SUFFIX} \
   -d finality-rpc.${CERTBOT_DOMAIN_SUFFIX} \
   -d demo.${CERTBOT_DOMAIN_SUFFIX} \
   -d finality.${CERTBOT_DOMAIN_SUFFIX}

--- a/scripts/babylon-integration/dns-setup.sh
+++ b/scripts/babylon-integration/dns-setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+set -a
+source $(pwd)/.env.babylon-integration
+set +a
+
+# reference: https://developers.cloudflare.com/api/operations/dns-records-for-a-zone-batch-dns-records
+create_dns_records() {
+    local names=("$@")
+    local records=""
+    
+    for name in "${names[@]}"; do
+        if [ -n "$records" ]; then
+            records="${records},"
+        fi
+        records="${records}
+        {
+            \"type\": \"A\",
+            \"name\": \"${name}.${CLOUDFLARE_DNS_SUBDOMAIN}\",
+            \"content\": \"$FINALITY_SYSTEM_SERVER_IP\",
+            \"proxied\": false
+        }"
+    done
+
+    curl --request POST \
+        --url "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/dns_records/batch" \
+        --header "Content-Type: application/json" \
+        --header "X-Auth-Email: $CLOUDFLARE_AUTH_EMAIL" \
+        --header "X-Auth-Key: $CLOUDFLARE_API_KEY" \
+        --data "{
+            \"posts\": [${records}]
+        }"
+}
+
+# finality gadget RPC, demo app, finality explorer
+create_dns_records "finality-rpc" "demo" "finality"

--- a/scripts/babylon-integration/proxy-setup.sh
+++ b/scripts/babylon-integration/proxy-setup.sh
@@ -52,3 +52,30 @@ sudo certbot certonly --nginx --non-interactive --agree-tos -m ${CERTBOT_EMAIL} 
   -d finality-rpc.${CERTBOT_DOMAIN_SUFFIX} \
   -d demo.${CERTBOT_DOMAIN_SUFFIX} \
   -d finality.${CERTBOT_DOMAIN_SUFFIX}
+
+# 3. create the nginx config files for each subdomain
+cp configs/nginx/finality-gadget-rpc.conf.template /etc/nginx/sites-available/finality-gadget-rpc.conf
+cp configs/nginx/demo-app.conf.template /etc/nginx/sites-available/demo-app.conf
+cp configs/nginx/finality-explorer.conf.template /etc/nginx/sites-available/finality-explorer.conf
+
+# 4. replace ${CERTBOT_DOMAIN_SUFFIX} in the nginx config files
+sed -i 's/\${CERTBOT_DOMAIN_SUFFIX}/'"${CERTBOT_DOMAIN_SUFFIX}"'/g' /etc/nginx/sites-available/*.conf
+
+# 5. enable the nginx config files
+mkdir -p /etc/nginx/sites-enabled
+ln -sf /etc/nginx/sites-available/finality-gadget-rpc.conf /etc/nginx/sites-enabled/
+ln -sf /etc/nginx/sites-available/demo-app.conf /etc/nginx/sites-enabled/
+ln -sf /etc/nginx/sites-available/finality-explorer.conf /etc/nginx/sites-enabled/
+
+# 6. verify the nginx config files
+nginx -t
+
+# 7. start nginx
+#
+# after running this, you can check the status of nginx by:
+# systemctl status nginx
+# 
+# see logs
+# journalctl -u nginx.service -f
+systemctl start nginx
+systemctl enable nginx


### PR DESCRIPTION
## Summary

i am following https://www.notion.so/snapchain/op-devnet-deployment-125a62189ff480abb8e0c7bb86db92bf to set up DNS and SSL but there are many steps so it's error-prone.

adding automation steps

## Test Plan

set env vars and run `sudo make dns-setup`

then check success
```
$ echo $?
0
```

also see


<img width="890" alt="image" src="https://github.com/user-attachments/assets/5d344772-b3f6-41b8-a470-b788f7143f80">

now verify the certs are valid for the 3 domains:

```
$ sudo openssl x509 -in /etc/letsencrypt/live/tohma.snapchain.dev/fullchain.pem -text | grep DNS:
                DNS:demo.tohma.snapchain.dev, DNS:finality-rpc.tohma.snapchain.dev, DNS:finality.tohma.snapchain.dev
```


modify the env var:
```
NEXT_PUBLIC_FINALITY_GADGET_API_URL=https://finality-rpc.tohma.snapchain.dev
```

and restart the finality explorer


now verify the finality gadget rpc:

```
curl https://finality-rpc.tohma.snapchain.dev/v1/chainSyncStatus
{"latest_block":118191,"latest_btc_finalized_block":118180,"earliest_btc_finalized_block":66709,"latest_eth_finalized_block":117989}
```

also https://finality.tohma.snapchain.dev/ and https://demo.tohma.snapchain.dev/ loads

test demo app rpc:

```
$ curl https://demo.tohma.snapchain.dev/api/getTransactions/0x00000000080480b4dee2a7fe4e59d7ce1289d83c
[]%
```