### PR TITLE
feat: pass param to make command toggle-cw-killswitch

### DIFF
--- a/.github/workflows/publish-babylon-deployment-utils.yml
+++ b/.github/workflows/publish-babylon-deployment-utils.yml
@@ -3,7 +3,7 @@ name: publish-babylon-deployment-utils
 on:
   push:
     branches:
-      - main
+      - '*'
     paths:
       - 'scripts/babylon-integration/utils/**'
 

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ register-consumer-chain:
 .PHONY: register-consumer-chain
 
 toggle-cw-killswitch:
-	@./scripts/babylon-integration/toggle-cw-killswitch.sh
+	@IS_ENABLED=$(ENABLE) ./scripts/babylon-integration/toggle-cw-killswitch.sh
 .PHONY: toggle-cw-killswitch
 
 teardown:

--- a/scripts/babylon-integration/toggle-cw-killswitch.sh
+++ b/scripts/babylon-integration/toggle-cw-killswitch.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ -z "${IS_ENABLED:-}" ]; then
+    echo "Error: ENABLE parameter is required"
+    echo "Usage: make toggle-cw-killswitch ENABLE=true|false"
+    exit 1
+fi
+
+sed -i.bak "s|\${IS_ENABLED}|$IS_ENABLED|g" .env.babylon-integration
+rm .env.babylon-integration.bak
+
 # setting the finality contract enabled value
 docker compose -f docker/docker-compose-babylon-integration.yml up -d toggle-cw-killswitch
 docker logs -f toggle-cw-killswitch

--- a/scripts/babylon-integration/toggle-cw-killswitch.sh
+++ b/scripts/babylon-integration/toggle-cw-killswitch.sh
@@ -7,7 +7,7 @@ if [ -z "${IS_ENABLED:-}" ]; then
     exit 1
 fi
 
-sed -i.bak "s|\${IS_ENABLED}|$IS_ENABLED|g" .env.babylon-integration
+sed -i.bak "s|IS_ENABLED=.*|IS_ENABLED=$IS_ENABLED|g" .env.babylon-integration
 rm .env.babylon-integration.bak
 
 # setting the finality contract enabled value


### PR DESCRIPTION
## Summary

It's hard to remember we need to first set `IS_ENABLED` in `.env.babylon-integration` and run `make toggle-cw-killswitch` after

I actually need to read the code and reference the PR https://github.com/Snapchain/babylon-deployment/pull/35 to recall how to use it

let's make it more straightforward e.g. `make toggle-cw-killswitch ENABLE=false`

## Test Plan

```
$ make toggle-cw-killswitch ENABLE=false                                                                                                    

[+] Running 1/1
 ✔ Container toggle-cw-killswitch  Started                                                                                                 0.5s
Setting enabled value to false
Contract address: bbn1vvxhq0vqg3f7xh2mjsxq3aekjj65cru48tf9r0y8pkms5ktee55ssgusje
gas estimate: 206196
{"height":"0","txhash":"2B72AA5C33C660D8EDA5386D3BDDE804520C675355493FF24200CCD3EE158924","codespace":"","code":0,"data":"","raw_log":"","logs":[],"info":"","gas_wanted":"0","gas_used":"0","tx":null,"timestamp":"","events":[]}
Set enabled tx hash: 2B72AA5C33C660D8EDA5386D3BDDE804520C675355493FF24200CCD3EE158924
```

`vi .env.babylon-integration` to verify the value changed from `true` to `false` after the operation

```
$ CONTRACT_ADDR="bbn1vvxhq0vqg3f7xh2mjsxq3aekjj65cru48tf9r0y8pkms5ktee55ssgusje"
$ CHAIN_ID=euphrates-0.5.0
$ RPC=https://rpc-euphrates.devnet.babylonlabs.io
$ QUERY='{"is_enabled":{}}'

// before the operation
$ babylond query wasm contract-state smart $CONTRACT_ADDR "$QUERY" --chain-id $CHAIN_ID --node $RPC -o json
{"data":true}

// after the operation
$ babylond query wasm contract-state smart $CONTRACT_ADDR "$QUERY" --chain-id $CHAIN_ID --node $RPC -o json
{"data":false}
```