### PR TITLE
fix: avoid using `rm -rf`

### DIFF
--- a/scripts/babylon-integration/stop-btc-staker.sh
+++ b/scripts/babylon-integration/stop-btc-staker.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 echo "Stopping btc-staker..."
 docker compose -f docker/docker-compose-babylon-integration.yml down btc-staker
 
-echo "Removing btc-staker directory..."
-sudo rm -rf $(pwd)/.btc-staker
+echo "Moving btc-staker directory..."
+sudo mv $(pwd)/.btc-staker $(pwd)/.btc-staker-deprecated-$(date +%Y%m%d%H%M%S)
 
 echo "Stopped btc-staker"
 echo

--- a/scripts/babylon-integration/stop-consumer-eotsmanager.sh
+++ b/scripts/babylon-integration/stop-consumer-eotsmanager.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 echo "Stopping consumer-eotsmanager..."
 docker compose -f docker/docker-compose-babylon-integration.yml down consumer-eotsmanager
 
-echo "Removing consumer-eotsmanager directory..."
-sudo rm -rf $(pwd)/.consumer-eotsmanager
+echo "Moving consumer-eotsmanager directory..."
+sudo mv $(pwd)/.consumer-eotsmanager $(pwd)/.consumer-eotsmanager-deprecated-$(date +%Y%m%d%H%M%S)
 
 echo "Stopped consumer-eotsmanager"
 echo

--- a/scripts/babylon-integration/stop-consumer-finality-provider.sh
+++ b/scripts/babylon-integration/stop-consumer-finality-provider.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 echo "Stopping consumer-finality-provider..."
 docker compose -f docker/docker-compose-babylon-integration.yml down consumer-finality-provider
 
-echo "Removing consumer-finality-provider directory..."
-sudo rm -rf $(pwd)/.consumer-finality-provider
+echo "Moving consumer-finality-provider directory..."
+sudo mv $(pwd)/.consumer-finality-provider $(pwd)/.consumer-finality-provider-deprecated-$(date +%Y%m%d%H%M%S)
 
 echo "Stopped consumer-finality-provider"
 echo

--- a/scripts/babylon-integration/stop-finality-gadget.sh
+++ b/scripts/babylon-integration/stop-finality-gadget.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 echo "Stopping finality-gadget..."
 docker compose -f docker/docker-compose-babylon-integration.yml down finality-gadget
 
-echo "Removing finality-gadget directory..."
-rm -rf $(pwd)/.finality-gadget
+echo "Moving finality-gadget directory..."
+sudo mv $(pwd)/.finality-gadget $(pwd)/.finality-gadget-deprecated-$(date +%Y%m%d%H%M%S)
 
 echo "Stopped finality-gadget"
 echo


### PR DESCRIPTION
## Summary

this is an extremely dangerous command and we should probably never use it in our code

## Test Plan

run 

```
make stop-consumer-eotsmanager
make stop-consumer-finality-provider
```

see folders moved instead of deleted